### PR TITLE
Update composer deps

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,7 +1,6 @@
 name: "CI"
 
-on:
-    pull_request:
+on: [push, pull_request]
 
 jobs:
     tests:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,0 +1,51 @@
+name: "CI"
+
+on:
+    pull_request:
+
+jobs:
+    tests:
+        name: "PHP ${{ matrix.php }} ${{ matrix.mode }}"
+
+        runs-on: ubuntu-latest
+
+        strategy:
+            fail-fast: false
+            matrix:
+                include:
+                  - php: '7.3'
+                  - php: '7.3'
+                    mode: low-deps
+                  - php: '7.4'
+                  - php: '8.0'
+                  - php: '8.1'
+                  - php: '8.1'
+                    mode: low-deps
+
+        steps:
+            - name: "Checkout code"
+              uses: actions/checkout@v2.3.3
+
+            - name: "Install PHP with extensions"
+              uses: shivammathur/setup-php@2.18.0
+              with:
+                  coverage: "none"
+                  php-version: ${{ matrix.php }}
+                  tools: composer
+
+            - name: "Validate composer.json"
+              run: "composer validate --strict --no-check-lock"
+
+            - name: "Install dependencies"
+              run: |
+                if [[ "${{ matrix.mode }}" = low-deps ]]; then
+                    composer u --prefer-lowest --prefer-stable --ansi
+                else
+                    composer u --ansi
+                fi
+
+            - run: vendor/bin/phpunit
+
+            - if: matrix.php == '8.1'
+              name: "Lint PHP files"
+              run: vendor/bin/phpcs -ps

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -45,6 +45,6 @@ jobs:
 
             - run: vendor/bin/phpunit
 
-            - if: matrix.php == '8.1' && matrix.mode != low-deps
+            - if: matrix.php == '8.1' && matrix.mode != 'low-deps'
               name: "Lint PHP files"
               run: vendor/bin/phpcs -ps

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -45,6 +45,6 @@ jobs:
 
             - run: vendor/bin/phpunit
 
-            - if: matrix.php == '8.1'
+            - if: matrix.php == '8.1' && matrix.mode != low-deps
               name: "Lint PHP files"
               run: vendor/bin/phpcs -ps

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /vendor
 /composer.lock
+/.phpunit.result.cache

--- a/composer.json
+++ b/composer.json
@@ -10,10 +10,10 @@
     ],
     "license": "MIT",
     "require": {
+        "php": ">=7.3",
         "guzzlehttp/guzzle": "^6.3.0 || ^7.4.0",
         "guzzlehttp/psr7": "^1.4.2 || ^2.2.0",
         "indigophp/hash-compat": "^1.1.0",
-        "paragonie/random_compat": ">=2",
         "psr/http-message": "^1.0.1",
         "symfony/yaml": "~3.4.5 || ^4.0.0 || ^5.0.0 || ^6.0.0"
     },

--- a/composer.json
+++ b/composer.json
@@ -10,13 +10,12 @@
     ],
     "license": "MIT",
     "require": {
-        "guzzlehttp/guzzle": "^6.3.0",
-        "guzzlehttp/psr7": "^1.4.2",
+        "guzzlehttp/guzzle": "^6.3.0 || ^7.4.0",
+        "guzzlehttp/psr7": "^1.4.2 || ^2.2.0",
         "indigophp/hash-compat": "^1.1.0",
         "paragonie/random_compat": ">=2",
         "psr/http-message": "^1.0.1",
-        "psr/log": "^1.0.2",
-        "symfony/yaml": "~3.4.5 || ^4.0.0"
+        "symfony/yaml": "~3.4.5 || ^4.0.0 || ^5.0.0 || ^6.0.0"
     },
     "autoload": {
         "psr-4": {
@@ -24,7 +23,7 @@
         }
     },
     "require-dev": {
-        "phpunit/phpunit": "^7.3.5",
+        "phpunit/phpunit": "^7.3.5 || ^9.5.0",
         "squizlabs/php_codesniffer": "^3.3.1"
     },
     "autoload-dev": {


### PR DESCRIPTION
Broadens the composer.json deps to allow more modern dependencies.

Drops psr/log dependency because it does not appear to be used.

Adds integration with github actions to test on PHP 7.3 -> PHP 8.1